### PR TITLE
Задание выполнено

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Project exclude paths
+/client/target/
+/server/target/

--- a/server/src/main/java/server/ClientHandler.java
+++ b/server/src/main/java/server/ClientHandler.java
@@ -5,6 +5,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class ClientHandler {
 
@@ -23,8 +25,9 @@ public class ClientHandler {
             this.server = server;
             in = new DataInputStream(socket.getInputStream());
             out = new DataOutputStream(socket.getOutputStream());
+            ExecutorService service = Executors.newCachedThreadPool();
 
-            new Thread(() -> {
+            service.execute(() -> {
                 try {
                     socket.setSoTimeout(120000);
 
@@ -125,8 +128,9 @@ public class ClientHandler {
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
+                    service.shutdown();
                 }
-            }).start();
+            });
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Применил CachedThreadPool();  - это единственный подходящий вариант.
Так как ограничивать количество потоков  не правильно. 
Поскольку количество клиентов заранее не известно. 

А поскольку количество потоков мы не ограничиваем, то замена Threads на ExecutorService нам никаких приемуществ не дает.